### PR TITLE
Set defaults for global ECUT and PCUT in guis

### DIFF
--- a/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
+++ b/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
@@ -3937,6 +3937,27 @@ call show_transport_parameter(6);
 "see if the user wants to scale elastic scattering cross sections"
 call set_elastic_parameter;
 
+"Revisit ECUTIN/PCUTIN"
+"If all global ECUT/PCUT values were left blank, then"
+"ECUTIN/PCUTIN at this point = 0.  Set ECUTIN/PCUTIN to AE/AP of default"
+"medium unless this is a vacuum, in which case set them equal to the highest"
+"AE/AP of all media.  Will only have implications for IREJCT_GLOBAL=1"
+IF(ECUTIN=0.0)[
+  IF(AIR_INDEX=1) [
+    ECUTIN=AE(1);
+  ]
+  ELSE [
+    DO I=1,NMED[ ECUTIN=MAX(ECUTIN,AE(I));]
+  ]
+]
+IF(PCUTIN=0.0)[
+  IF(AIR_INDEX=1) [
+    PCUTIN=AP(1);
+  ]
+  ELSE [
+    DO I=1,NMED[ PCUTIN=MAX(PCUTIN,AP(I));]
+  ]
+]
 "Note: default region densities (RHOR=0) set to those of PEGS files in HATCH
 ;
 "*******************************************************************************

--- a/HEN_HOUSE/omega/progs/gui/beamnrc/new_create_file_egsnrc.tcl
+++ b/HEN_HOUSE/omega/progs/gui/beamnrc/new_create_file_egsnrc.tcl
@@ -484,8 +484,19 @@ proc create_file { file } {
     puts $file " #########################"
     puts $file " :Start MC Transport Parameter:"
     puts $file " "
-    puts $file " Global ECUT= $values(ecut)"
-    puts $file " Global PCUT= $values(pcut)"
+    # ECUT and PCUT cannot be blank
+    set values(ecut) [string trim $values(ecut)]
+    if {$values(ecut) == {}} {
+       puts $file " Global ECUT= 0"
+    } else {
+       puts $file " Global ECUT= $values(ecut)"
+    }
+    set values(pcut) [string trim $values(pcut)]
+    if {$values(pcut) == {}} {
+       puts $file " Global PCUT= 0"
+    } else {
+       puts $file " Global PCUT= $values(pcut)"
+    }
     puts $file " Global SMAX= $values(smaxir)"
     puts $file " ESTEPE= $values(estepe)"
     puts $file " XIMAX= $values(ximax)"

--- a/HEN_HOUSE/omega/progs/gui/dosxyznrc/create_file_nrc.tcl
+++ b/HEN_HOUSE/omega/progs/gui/dosxyznrc/create_file_nrc.tcl
@@ -454,8 +454,19 @@ set str "$ivary($i), $angfixed($i), $ang1($i), $ang2($i), $nang($i), $pang($i)"
     puts $file " #########################"
     puts $file " :Start MC Transport Parameter:"
     puts $file " "
-    puts $file " Global ECUT= $values(ecut)"
-    puts $file " Global PCUT= $values(pcut)"
+    # ECUT and PCUT cannot be blank
+    set values(ecut) [string trim $values(ecut)]
+    if {$values(ecut) == {}} {
+       puts $file " Global ECUT= 0"
+    } else {
+       puts $file " Global ECUT= $values(ecut)"
+    }
+    set values(pcut) [string trim $values(pcut)]
+    if {$values(pcut) == {}} {
+       puts $file " Global PCUT= 0"
+    } else {
+       puts $file " Global PCUT= $values(pcut)"
+    }
     puts $file " Global SMAX= $values(smaxir)"
     puts $file " ESTEPE= $values(estepe)"
     puts $file " XIMAX= $values(ximax)"

--- a/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
+++ b/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
@@ -1970,28 +1970,6 @@ skindepth_for_bca=0;
 
 call get_transport_parameter(-1);
 
-"now check to see if ECUTIN>ECUT or PCUTIN>PCUT"
-IF(ECUTIN>ECUT)[ "reset ecut in all regions to ecutin"
-   OUTPUT ECUT;
-    (/' ****WARNING****'/
-      ' ECUTIN > ECUT input in EGSnrc parameters ( ',F10.4,' MeV).'/
-      ' ECUT defaults to ECUTIN.'/);
-   ECUT=ECUTIN;
-]
-ELSE[
-   ECUTIN=ECUT;
-]
-IF(PCUTIN>PCUT)[ "reset ecut in all regions to ecutin"
-   OUTPUT PCUT;
-    (/' ****WARNING****'/
-      ' PCUTIN > PCUT input in EGSnrc parameters ( ',F10.4,' MeV).'/
-      ' PCUT defaults to PCUTIN.'/);
-   PCUT=PCUTIN;
-]
-ELSE[
-   ECUTIN=ECUT;
-]
-
 IF((~exact_bca | transport_algorithm=$PRESTA--I) & SMAXIR=1e10)[
 "if we get to here with the default value of SMAX (1e10), then"
 "assume that this is because the SMAX input does not exist, the user"
@@ -2015,6 +1993,30 @@ call show_transport_parameter(iout); " print the transport parameter settings"
 "=========================================================================="
 "End of block added by Ernesto Mainegra-Hing Dec 2011"
 "=========================================================================="
+
+"now check to see if ECUTIN>ECUT or PCUTIN>PCUT"
+"or, in the case where GUI inputs for ECUT/PCUT were left blank and"
+"ECUT/PCUT defaulted to AE/AP in hatch, ECUT>ECUTIN or PCUT>PCUTIN"
+IF(ECUTIN>ECUT)[ "reset ecut in all regions to ecutin"
+   OUTPUT ECUT;
+    (/' ****WARNING****'/
+      ' ECUTIN > ECUT input in EGSnrc parameters ( ',F10.4,' MeV).'/
+      ' ECUT defaults to ECUTIN.'/);
+   ECUT=ECUTIN;
+]
+ELSE[
+   ECUTIN=ECUT;
+]
+IF(PCUTIN>PCUT)[ "reset ecut in all regions to ecutin"
+   OUTPUT PCUT;
+    (/' ****WARNING****'/
+      ' PCUTIN > PCUT input in EGSnrc parameters ( ',F10.4,' MeV).'/
+      ' PCUT defaults to PCUTIN.'/);
+   PCUT=PCUTIN;
+]
+ELSE[
+   ECUTIN=ECUT;
+]
 
 "call this here so that BEAM simulation source can get i_parallel if"
 "pprocess is used"


### PR DESCRIPTION
Save the global ECUT and PCUT values as "0" in the .egsinp file if they
are left blank in the guis.

This results in the following default behaviour in subroutine HATCH:

1) For BEAMnrc, region-by-region setting of ECUT(i) or PCUT(i) to
   AE(med(i)) or AP(med(i)), respectively.

2) For DOSXYZnrc, setting of the single value of ECUT or PCUT that
   applies to all regions to the maximum of value of AE or AP over all
   media.

Modifications to BEAMnrc and DOSXYZnrc were necessary, to ensure that
ECUTIN or PCUTIN, the actual input variable for global ECUT or PCUT, was
also set to a value other than zero. ECUTIN, specifically, is used to
determine range for range rejection and running with this set to zero
may cause a crash.

In BEAMnrc, this means resetting ECUTIN or PCUTIN to AE or AP of the
default medium (or the maximum AE or AP over all media if the default
medium is vacuum). For DOSXYZnrc, ECUTIN or PCUTIN gets reset to the
maximum AE or AP over all media (i.e., the new value of ECUT or PCUT set
in HATCH).